### PR TITLE
Don't create a file if the download fails

### DIFF
--- a/lib/jets/gems/extract/base.rb
+++ b/lib/jets/gems/extract/base.rb
@@ -41,13 +41,12 @@ module Jets::Gems::Extract
       end
 
       say "Downloading..."
+      downloaded = URI.open(url, 'rb') { |read_file| read_file.read }
+
       FileUtils.mkdir_p(File.dirname(dest)) # ensure parent folder exists
 
-      File.open(dest, 'wb') do |saved_file|
-        URI.open(url, 'rb') do |read_file|
-          saved_file.write(read_file.read)
-        end
-      end
+      File.open(dest, 'wb') { |saved_file| saved_file.write(downloaded) }
+
       dest
     end
 


### PR DESCRIPTION
Don't create a file if the download fails.

Currently, even if a serverlessgems download results in a 403 error due to rate limit or some other reason, a zip file with empty contents is created. If there is an empty file, the next download will assume that the gem is already there, so there is a risk that the deployment will proceed with empty contents.